### PR TITLE
- Fix escape key not working after delete a preset

### DIFF
--- a/WaymarkPresetPlugin/Windows/Library/LibraryWindow.cs
+++ b/WaymarkPresetPlugin/Windows/Library/LibraryWindow.cs
@@ -684,7 +684,10 @@ public class LibraryWindow : Window, IDisposable
     public void TryDeselectPreset()
     {
         if (!Plugin.EditorWindow.EditingPreset)
+        {
+            Plugin.InfoPaneWindow.IsOpen = false;
             SelectedPreset = -1;
+        }
     }
 
     private bool IsZoneFilteredBySearch(string zoneFilterString, ZoneInfo zoneInfo)


### PR DESCRIPTION
Seems like `InfoPaneWindow` is not closed properly after delete.
Tested in-game, but need further testing. Fix #8 .