### PR TITLE
Fix InfoPane focus

### DIFF
--- a/WaymarkPresetPlugin/Windows/InfoPane/InfoPane.cs
+++ b/WaymarkPresetPlugin/Windows/InfoPane/InfoPane.cs
@@ -22,17 +22,18 @@ public class InfoPaneWindow : Window, IDisposable
     public InfoPaneWindow(Plugin plugin) : base("Preset Info###PresetInfo")
     {
         Plugin = plugin;
-        Flags = ImGuiWindowFlags.NoResize;
+        Flags = ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoFocusOnAppearing;
         Size = new Vector2(100, 100);
-
-        IsOpen = true;
     }
 
     public void Dispose() { }
 
-    public override bool DrawConditions()
+    public override void PreOpenCheck()
     {
-        return Plugin.LibraryWindow.IsOpen && (Plugin.LibraryWindow.SelectedPreset >= 0 || Plugin.Configuration.AlwaysShowInfoPane);
+        if (!Plugin.LibraryWindow.IsOpen || (Plugin.LibraryWindow.SelectedPreset < 0 && !Plugin.Configuration.AlwaysShowInfoPane))
+        {
+            IsOpen = false;
+        }
     }
 
     public override void PreDraw()

--- a/WaymarkPresetPlugin/Windows/Library/LibraryWindow.cs
+++ b/WaymarkPresetPlugin/Windows/Library/LibraryWindow.cs
@@ -87,6 +87,14 @@ public class LibraryWindow : Window, IDisposable
         FieldMarkerAddonWasOpen = FieldMarkerAddonVisible;
     }
 
+    public override void OnOpen()
+    {
+        if (Plugin.Configuration.AlwaysShowInfoPane || SelectedPreset > 0)
+        {
+            Plugin.InfoPaneWindow.IsOpen = true;
+        }
+    }
+
     public override void Draw()
     {
         //	Draw the window.


### PR DESCRIPTION
Should behave almost the same as before (info pane can be force-closed but reopens when selecting a preset, or when reopening the library window if a preset is selected or "always show" is set). Fixes the issue where the info pane can steal focus while invisible and break the ESC key.